### PR TITLE
AB#62111 reduce the size of the CSV

### DIFF
--- a/last-access-report/.gitignore
+++ b/last-access-report/.gitignore
@@ -1,5 +1,6 @@
 # We don't want production variables appearing in the git repository
 *.env
 
-# Or, for that matter, swp files
+# Or, for that matter, swp files and CSVs
 *.swp
+*.csv

--- a/last-access-report/README.md
+++ b/last-access-report/README.md
@@ -11,7 +11,10 @@ To run this:
 * curl
 * bash
 * jq
-
+* sed
+* head
+* csvsort - part of csvkit
+* csvcut - part of csvkit
 
 ## Usage
 

--- a/last-access-report/last-login-report.sh
+++ b/last-access-report/last-login-report.sh
@@ -62,10 +62,10 @@ do
 			# grab the report's URL & remove quotes
 			url=`echo ${check_report_json} | jq -r '.attachment.url'`
 
-			echo "URL of report is ${url} Fetching ............}"
+			#DEBUG echo "URL of report is ${url} Fetching ............}"
 
-			# grab the report
-			curl  -L -X GET ${url} -H "Authorization: Bearer ${token}" 
+			# grab the report, put last accessed column first, delete all lines where no login, sort on first column and write out first 100 lines
+			curl  -L -X GET ${url} -H "Authorization: Bearer ${token}" | csvcut -c 4,1,2,3,5 | sed -e '/^,/d'| csvsort -r -c 1 | head -100
 			exit 0
 		else
 			sleep 300
@@ -73,8 +73,3 @@ do
 	fi
 done
 
-
-
-
-
-echo "out of loop"


### PR DESCRIPTION
The full report is > 7M and cant be sent via email, in any case >99% of the rows are not needed. The new CSV is ordered, users who have never logged in are removed & the most recent 100 users who have logged in.

Also removed some debugging logging which was left in by mistake