### PR TITLE
AB#72580 changed the script so it only bails if the canvas login isnt…

### DIFF
--- a/add-admins/add-admins.sh
+++ b/add-admins/add-admins.sh
@@ -43,11 +43,13 @@ do
     if [ $code -eq 22 ]; then
       cat notice.txt
       echo "Login failed for: ${host}\nCheck token is valid"
+      # since we cant login, we may as well quit
+      exit 1
     else
+      # log the error and carry on
       cat notice.txt
       echo "Failed to add: $admin for: $host"
     fi
-    exit 1
   fi
 done
 


### PR DESCRIPTION
… possible, if an admin cannot be set up then rather than abort, simply log the problem and carry on in a typically stiff-upper-lip British kind of way